### PR TITLE
Add support for AzureDefaultCredential-based auth

### DIFF
--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -33,8 +33,12 @@
             <artifactId>jgroups</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-storage</artifactId>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/azure/src/test/java/org/jgroups/protocols/azure/AZURE_PINGDiscoveryTest.java
+++ b/azure/src/test/java/org/jgroups/protocols/azure/AZURE_PINGDiscoveryTest.java
@@ -50,18 +50,15 @@ public class AZURE_PINGDiscoveryTest {
     public void testProtocolStack() throws Exception {
         JChannel channel = new JChannel(STACK_XML_CONFIGURATION);
 
-        channel.getProtocolStack().getProtocols().replaceAll(protocol -> {
-            if (protocol instanceof AZURE_PING) {
-                return new AZURE_PING();
-            } else {
-                return protocol;
-            }
-        });
-
-        try {
+        try (channel) {
+            channel.getProtocolStack().getProtocols().replaceAll(protocol -> {
+                if (protocol instanceof AZURE_PING) {
+                    return new AZURE_PING();
+                } else {
+                    return protocol;
+                }
+            });
             channel.connect(RANDOM_CLUSTER_NAME);
-        } finally {
-            channel.close();
         }
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
     <properties>
         <version.org.jgroups>5.3.6.Final</version.org.jgroups>
-        <version.com.microsoft.azure.azure-storage>8.6.6</version.com.microsoft.azure.azure-storage>
+        <version.com.azure-azure-sdk-bom>1.2.23</version.com.azure-azure-sdk-bom>
 
         <!-- Overridden versions as managed by WildFly -->
         <version.com.fasterxml.jackson>2.17.1</version.com.fasterxml.jackson> <!-- azure-storage uses 2.6.0 -->
@@ -81,17 +81,16 @@
                 <artifactId>jgroups</artifactId>
                 <version>${version.org.jgroups}</version>
             </dependency>
+
+            <!-- Pull in Azure bills of material to ensure that the SDK components fit together -->
             <dependency>
-                <groupId>com.microsoft.azure</groupId>
-                <artifactId>azure-storage</artifactId>
-                <version>${version.com.microsoft.azure.azure-storage}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>${version.com.azure-azure-sdk-bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
+
 
             <!-- Override azure-storage dependencies versions with WildFly-managed ones -->
             <dependency>


### PR DESCRIPTION
Unfortunately, this PR contains a lot more changes than initially intended.
Seems like the coordinates of the Azure Storage Client library have changed and the API of the implementation was completely overhauled as well.

I took the time to try and adhere to current best practices when working with the Azure SDK for Java, e.g. utilizing the bills-of-material (BOM) dependency to make sure that all Azure-related libraries fit together, nicely.

I did not (yet) test the new library in my Cloud environment, but wanted to get this drafted PR out of the door as soon as possible to gather some feedback from the original maintainer.

@rhusar 

Closes: #177