### PR TITLE
Upgrade to Azure Storage Blob SDK 12.x and support DefaultAzureCredential; fixes #245 and #177

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,11 +13,12 @@ Azure Java SDK.
 |===
 |Property name |Description |Required / Default value 
 
-|`storage_account_name` |The name of the storage account. |_Required._ 
-|`storage_access_key` |The secret account access key. |_Required._ 
-|`container` |Container to store ping information in. Must be valid DNS name. |_Required._ 
-|`use_https` |Whether or not to use HTTPS to connect to Azure. |`true` 
-|`endpoint_suffix` |The endpointSuffix to use. | 
+|`storage_account_name` |The name of the storage account. |_Required._
+|`storage_access_key` |The secret account access key. If not specified, `DefaultAzureCredential` is used instead. |_Optional._
+|`container` |Container to store ping information in. Must be valid DNS name. |_Required._
+|`use_https` |Whether or not to use HTTPS to connect to Azure. |`true`
+|`endpoint_suffix` |The endpointSuffix to use. |
+|`blob_storage_uri` |The full blob service endpoint URI. When set, overrides `use_https` and `endpoint_suffix`. |
 |===
 
 === WildFly 10.1 or later / JBoss EAP 7.0 or later
@@ -112,7 +113,7 @@ If valid credentials are not provided, tests requiring them are skipped.
 |===
 |Version (branch) |JGroups version |Azure Storage version |Java version 
 
-|3.x |5.5.x |TBD |17 
+|3.x |5.5.x |12.x |17
 |2.x |5.1.x - 5.4.x |8.6.6 |11 
 |1.3.x |4.2.x |8.6.6 |8 
 |1.2.x |4.0.x |6.1.0 |8 

--- a/pom.xml
+++ b/pom.xml
@@ -78,45 +78,41 @@
         <jdk.min.version>${maven.compiler.release}</jdk.min.version>
         <nexus.staging.tag>${project.groupId}-${project.version}</nexus.staging.tag>
 
-        <!-- https://mvnrepository.com/artifact/org.jgroups/jgroups -->
-        <version.org.jgroups>5.5.4.Final</version.org.jgroups>
-        <!-- https://mvnrepository.com/artifact/com.microsoft.azure/azure-storage -->
-        <version.com.microsoft.azure.azure-storage>8.6.6</version.com.microsoft.azure.azure-storage>
+        <!-- Runtime dependencies -->
+        <version.org.jgroups>5.5.4.Final</version.org.jgroups> <!-- Reference: https://mvnrepository.com/artifact/org.jgroups/jgroups -->
+        <version.com.azure.azure-sdk-bom>1.3.6</version.com.azure.azure-sdk-bom> <!-- Reference: https://mvnrepository.com/artifact/com.azure/azure-sdk-bom -->
 
-        <!-- Overridden versions as managed by WildFly -->
-        <version.com.fasterxml.jackson>2.21.2</version.com.fasterxml.jackson> <!-- azure-storage uses 2.6.0 -->
-        <version.org.slf4j>2.0.17</version.org.slf4j> <!-- azure-storage uses 1.7.12 -->
-
-        <!-- https://mvnrepository.com/artifact/org.testcontainers/testcontainers -->
-        <version.org.testcontainers>2.0.4</version.org.testcontainers>
+        <!-- Test dependencies -->
+        <version.org.testcontainers>2.0.4</version.org.testcontainers> <!-- Reference: https://mvnrepository.com/artifact/org.testcontainers/testcontainers -->
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <version>${version.com.azure.azure-sdk-bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
+        <!-- Runtime dependencies -->
         <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
             <version>${version.org.jgroups}</version>
         </dependency>
         <dependency>
-            <groupId>com.microsoft.azure</groupId>
-            <artifactId>azure-storage</artifactId>
-            <version>${version.com.microsoft.azure.azure-storage}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${version.com.fasterxml.jackson}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${version.org.slf4j}</version>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
+++ b/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
@@ -18,18 +18,17 @@ package org.jgroups.protocols.azure;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.net.URI;
 import java.util.List;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.StorageCredentials;
-import com.microsoft.azure.storage.StorageUri;
-import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
-import com.microsoft.azure.storage.blob.CloudBlob;
-import com.microsoft.azure.storage.blob.CloudBlobClient;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import com.microsoft.azure.storage.blob.ListBlobItem;
+import com.azure.core.util.BinaryData;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.common.StorageSharedKeyCredential;
 import org.jgroups.Address;
 import org.jgroups.annotations.Property;
 import org.jgroups.conf.ClassConfigurator;
@@ -40,7 +39,7 @@ import org.jgroups.protocols.PingData;
 import org.jgroups.util.Responses;
 
 /**
- * Implementation of PING protocols for AZURE using Storage Blobs. See /DESIGN.md for design.
+ * Implementation of a {@link org.jgroups.protocols.Discovery} protocol for Microsoft Azure using Blob Service as cluster information store.
  *
  * @author Radoslav Husar
  */
@@ -51,7 +50,7 @@ public class AZURE_PING extends FILE_PING {
     @Property(description = "The name of the storage account.")
     protected String storage_account_name;
 
-    @Property(description = "The secret account access key.", exposeAsManagedAttribute = false)
+    @Property(description = "The secret account access key. If not specified, DefaultAzureCredential is used instead.", exposeAsManagedAttribute = false)
     protected String storage_access_key;
 
     @Property(description = "Container to store ping information in. Must be valid DNS name.")
@@ -63,13 +62,13 @@ public class AZURE_PING extends FILE_PING {
     @Property(description = "The endpointSuffix to use.")
     protected String endpoint_suffix;
 
+    // n.b. primarily used for testing with Azurite where the endpoint needs to be overridden; exposed here for more configuration flexibility
     @Property(description = "The full blob service endpoint URI. When set, overrides use_https and endpoint_suffix.")
-    // n.b. primarily used for testing with Azurite where the endpoint needs to be overridden
     protected String blob_storage_uri;
 
     public static final int STREAM_BUFFER_SIZE = 4096;
 
-    private CloudBlobContainer containerReference;
+    private BlobContainerClient containerClient;
 
     static {
         ClassConfigurator.addProtocol((short) 530, AZURE_PING.class);
@@ -84,18 +83,31 @@ public class AZURE_PING extends FILE_PING {
         this.validateConfiguration();
 
         try {
-            StorageCredentials credentials = new StorageCredentialsAccountAndKey(storage_account_name, storage_access_key);
-            CloudStorageAccount storageAccount;
-            if (blob_storage_uri != null && !blob_storage_uri.isEmpty()) {
-                storageAccount = new CloudStorageAccount(credentials, new StorageUri(new URI(blob_storage_uri)), null, null);
-            } else if (endpoint_suffix != null) {
-                storageAccount = new CloudStorageAccount(credentials, use_https, endpoint_suffix);
+            BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
+
+            // Set credential: use shared key if access key is provided, otherwise fall back to DefaultAzureCredential
+            if (storage_access_key != null) {
+                builder.credential(new StorageSharedKeyCredential(storage_account_name, storage_access_key));
             } else {
-                storageAccount = new CloudStorageAccount(credentials, use_https);
+                try {
+                    builder.credential(new DefaultAzureCredentialBuilder().build());
+                } catch (NoClassDefFoundError e) {
+                    throw new IllegalStateException("DefaultAzureCredential requires 'com.azure:azure-identity' dependency on the classpath.", e);
+                }
             }
-            CloudBlobClient blobClient = storageAccount.createCloudBlobClient();
-            containerReference = blobClient.getContainerReference(container);
-            boolean created = containerReference.createIfNotExists();
+
+            // Set endpoint
+            if (blob_storage_uri != null && !blob_storage_uri.isEmpty()) {
+                builder.endpoint(blob_storage_uri);
+            } else {
+                String suffix = (endpoint_suffix != null) ? endpoint_suffix : "core.windows.net";
+                String protocol = use_https ? "https" : "http";
+                builder.endpoint(String.format("%s://%s.blob.%s", protocol, storage_account_name, suffix));
+            }
+
+            BlobServiceClient blobServiceClient = builder.buildClient();
+            containerClient = blobServiceClient.getBlobContainerClient(container);
+            boolean created = containerClient.createIfNotExists();
 
             if (created) {
                 log.info("Created container named '%s'.", container);
@@ -115,9 +127,9 @@ public class AZURE_PING extends FILE_PING {
                 || container.startsWith("-") || container.length() < 3 || container.length() > 63) {
             throw new IllegalArgumentException("Container name must be configured and must meet Azure requirements (must be a valid DNS name).");
         }
-        // Account name and access key must be both configured for write access
-        if (storage_account_name == null || storage_access_key == null) {
-            throw new IllegalArgumentException("Account name and key must be configured.");
+        // Account name must be configured
+        if (storage_account_name == null) {
+            throw new IllegalArgumentException("Account name must be configured.");
         }
         // Let's inform users here that https would be preferred
         if (!use_https) {
@@ -140,18 +152,14 @@ public class AZURE_PING extends FILE_PING {
 
         String prefix = sanitize(clustername);
 
-        Iterable<ListBlobItem> listBlobItems = containerReference.listBlobs(prefix);
-        for (ListBlobItem blobItem : listBlobItems) {
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(prefix);
+        for (BlobItem blobItem : containerClient.listBlobs(options, null)) {
             try {
-                // If the item is a blob and not a virtual directory.
-                // n.b. what an ugly API this is
-                if (blobItem instanceof CloudBlob) {
-                    CloudBlob blob = (CloudBlob) blobItem;
-                    ByteArrayOutputStream os = new ByteArrayOutputStream(STREAM_BUFFER_SIZE);
-                    blob.download(os);
-                    byte[] pingBytes = os.toByteArray();
-                    parsePingData(pingBytes, members, responses);
-                }
+                BlobClient blobClient = containerClient.getBlobClient(blobItem.getName());
+                ByteArrayOutputStream os = new ByteArrayOutputStream(STREAM_BUFFER_SIZE);
+                blobClient.downloadStream(os);
+                byte[] pingBytes = os.toByteArray();
+                parsePingData(pingBytes, members, responses);
             } catch (Exception t) {
                 log.error("Error fetching ping data.");
             }
@@ -197,8 +205,8 @@ public class AZURE_PING extends FILE_PING {
             byte[] data = out.toByteArray();
 
             // Upload the file
-            CloudBlockBlob blob = containerReference.getBlockBlobReference(filename);
-            blob.upload(new ByteArrayInputStream(data), data.length);
+            BlobClient blobClient = containerClient.getBlobClient(filename);
+            blobClient.upload(BinaryData.fromBytes(data), true);
 
         } catch (Exception ex) {
             log.error("Error marshalling and uploading ping data.", ex);
@@ -215,8 +223,8 @@ public class AZURE_PING extends FILE_PING {
         String filename = addressToFilename(clustername, addr);
 
         try {
-            CloudBlockBlob blob = containerReference.getBlockBlobReference(filename);
-            boolean deleted = blob.deleteIfExists();
+            BlobClient blobClient = containerClient.getBlobClient(filename);
+            boolean deleted = blobClient.deleteIfExists();
 
             if (deleted) {
                 log.debug("Tried to delete file '%s' but it was already deleted.", filename);
@@ -237,18 +245,15 @@ public class AZURE_PING extends FILE_PING {
 
         clustername = sanitize(clustername);
 
-        Iterable<ListBlobItem> listBlobItems = containerReference.listBlobs(clustername);
-        for (ListBlobItem blobItem : listBlobItems) {
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(clustername);
+        for (BlobItem blobItem : containerClient.listBlobs(options, null)) {
             try {
-                // If the item is a blob and not a virtual directory.
-                if (blobItem instanceof CloudBlob) {
-                    CloudBlob blob = (CloudBlob) blobItem;
-                    boolean deleted = blob.deleteIfExists();
-                    if (deleted) {
-                        log.trace("Deleted file '%s'.", blob.getName());
-                    } else {
-                        log.debug("Tried to delete file '%s' but it was already deleted.", blob.getName());
-                    }
+                BlobClient blobClient = containerClient.getBlobClient(blobItem.getName());
+                boolean deleted = blobClient.deleteIfExists();
+                if (deleted) {
+                    log.trace("Deleted file '%s'.", blobItem.getName());
+                } else {
+                    log.debug("Tried to delete file '%s' but it was already deleted.", blobItem.getName());
                 }
             } catch (Exception e) {
                 log.error("Error deleting ping data for cluster '" + clustername + "'.", e);

--- a/src/test/java/org/jgroups/protocols/azure/AZURE_PINGConfigurationTest.java
+++ b/src/test/java/org/jgroups/protocols/azure/AZURE_PINGConfigurationTest.java
@@ -44,6 +44,13 @@ public class AZURE_PINGConfigurationTest {
         azure.validateConfiguration();
     }
 
+    @Test
+    public void testValidationWithoutAccessKey() {
+        azure.storage_account_name = "myaccount";
+        azure.container = "mycontainer";
+        azure.validateConfiguration();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testValidationWrongContainerName() {
         azure.storage_account_name = "myaccount";

--- a/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
@@ -54,7 +54,9 @@ public class AzuriteAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscov
         // Using 'latest' here often breaks the tests.
         // The version will have to be explicitly managed here for reproducible builds/CI.
         // n.b. for reference https://mcr.microsoft.com/en-us/artifact/mar/azure-storage/azurite/tags
-        azurite = new GenericContainer<>("mcr.microsoft.com/azure-storage/azurite:3.33.0")
+        // n.b. --skipApiVersionCheck is needed because Azurite doesn't yet support the 2026-02-06 API version used by the latest SDK
+        azurite = new GenericContainer<>("mcr.microsoft.com/azure-storage/azurite:3.35.0")
+                .withCommand("azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck")
                 .withExposedPorts(AZURITE_BLOB_PORT);
         azurite.start();
 


### PR DESCRIPTION
Migrate from legacy com.microsoft.azure:azure-storage to com.azure:azure-storage-blob managed by azure-sdk-bom.
When storage_access_key is not specified, fall back to DefaultAzureCredential from azure-identity (optional dependency).