### PR TITLE
Support connection_string property for AZURE_PING; fixes #248

### DIFF
--- a/DESIGN.adoc
+++ b/DESIGN.adoc
@@ -14,9 +14,10 @@ as JDBC_PING. It is based on blob storage.
 To use AZURE_PING add the implementing protocol, org.jgroups.protocols.AZURE_PING, to the stack and configure the
 following properties needed to authenticate and use the Azure Storage service:
 
+* container - the name of the container to use for ping data (required)
 * storage_account_name - the name of the storage account
 * storage_access_key - the secret access key
-* container - the name of the container to use for PING data
+* connection_string - alternatively, a connection string can be used instead of the above two properties
 
 To find out these values, do the following:
 

--- a/README.adoc
+++ b/README.adoc
@@ -13,8 +13,9 @@ Azure Java SDK.
 |===
 |Property name |Description |Required / Default value 
 
-|`storage_account_name` |The name of the storage account. |_Required._
+|`storage_account_name` |The name of the storage account. |_Required (unless `connection_string` is set)._
 |`storage_access_key` |The secret account access key. If not specified, `DefaultAzureCredential` is used instead. |_Optional._
+|`connection_string` |Azure Storage connection string. When set, overrides `storage_account_name`, `storage_access_key`, `use_https`, `endpoint_suffix`, and `blob_storage_uri`. |_Optional._
 |`container` |Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL. |_Required._
 |`use_https` |Whether or not to use HTTPS to connect to Azure. |`true`
 |`endpoint_suffix` |The endpointSuffix to use. |
@@ -98,7 +99,7 @@ Or use Maven wrapper for convenience:
 
 == Testing
 
-To run all tests, credentials for Azure are expected. These can be supplied using test properties:
+To run all tests, credentials for Azure are expected. These can be supplied either using individual properties for tests:
 
 ----
 export account_name=foo
@@ -106,7 +107,16 @@ export access_key=bar
 mvn test -Dazure.account_name="${account_name}" -Dazure.access_key="${access_key}" -Djava.net.preferIPv4Stack=true
 ----
 
-If valid credentials are not provided, tests requiring them are skipped.
+or a connection string can be used:
+
+----
+mvn test -Dazure.connection_string="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+----
+
+If valid credentials are not provided, tests that require them are skipped (using `org.junit.Assume`).
+
+There are also variants of the tests that run against a mock Blob service running in a container.
+To run those tests, a valid podman/Docker environment is required.
 
 == Support Matrix
 

--- a/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
+++ b/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
@@ -53,6 +53,9 @@ public class AZURE_PING extends FILE_PING {
     @Property(description = "The secret account access key. If not specified, DefaultAzureCredential is used instead.", exposeAsManagedAttribute = false)
     protected String storage_access_key;
 
+    @Property(description = "Azure Storage connection string. When set, overrides storage_account_name, storage_access_key, use_https, endpoint_suffix, and blob_storage_uri.", exposeAsManagedAttribute = false)
+    protected String connection_string;
+
     @Property(description = "Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL.")
     protected String container;
 
@@ -93,24 +96,28 @@ public class AZURE_PING extends FILE_PING {
         try {
             BlobServiceClientBuilder builder = new BlobServiceClientBuilder();
 
-            // Set credential: use shared key if access key is provided, otherwise fall back to DefaultAzureCredential
-            if (storage_access_key != null && !storage_access_key.isEmpty()) {
-                builder.credential(new StorageSharedKeyCredential(storage_account_name, storage_access_key));
+            if (connection_string != null && !connection_string.isEmpty()) {
+                builder.connectionString(connection_string);
             } else {
-                try {
-                    builder.credential(new DefaultAzureCredentialBuilder().build());
-                } catch (NoClassDefFoundError e) {
-                    throw new IllegalStateException("DefaultAzureCredential requires 'com.azure:azure-identity' dependency on the classpath.", e);
+                // Set credential: use shared key if access key is provided, otherwise fall back to DefaultAzureCredential
+                if (storage_access_key != null && !storage_access_key.isEmpty()) {
+                    builder.credential(new StorageSharedKeyCredential(storage_account_name, storage_access_key));
+                } else {
+                    try {
+                        builder.credential(new DefaultAzureCredentialBuilder().build());
+                    } catch (NoClassDefFoundError e) {
+                        throw new IllegalStateException("DefaultAzureCredential requires 'com.azure:azure-identity' dependency on the classpath.", e);
+                    }
                 }
-            }
 
-            // Set endpoint
-            if (blob_storage_uri != null && !blob_storage_uri.isEmpty()) {
-                builder.endpoint(blob_storage_uri);
-            } else {
-                String suffix = (endpoint_suffix != null) ? endpoint_suffix : "core.windows.net";
-                String protocol = use_https ? "https" : "http";
-                builder.endpoint(String.format("%s://%s.blob.%s", protocol, storage_account_name, suffix));
+                // Set endpoint
+                if (blob_storage_uri != null && !blob_storage_uri.isEmpty()) {
+                    builder.endpoint(blob_storage_uri);
+                } else {
+                    String suffix = (endpoint_suffix != null) ? endpoint_suffix : "core.windows.net";
+                    String protocol = use_https ? "https" : "http";
+                    builder.endpoint(String.format("%s://%s.blob.%s", protocol, storage_account_name, suffix));
+                }
             }
 
             BlobServiceClient blobServiceClient = builder.buildClient();
@@ -135,12 +142,12 @@ public class AZURE_PING extends FILE_PING {
                 || container.startsWith("-") || container.length() < 3 || container.length() > 63) {
             throw new IllegalArgumentException("Container name must be configured and must meet Azure requirements (must be a valid DNS name).");
         }
-        // Account name must be configured
-        if (storage_account_name == null) {
-            throw new IllegalArgumentException("Account name must be configured.");
+        // Either connection_string or storage_account_name must be configured
+        if ((connection_string == null || connection_string.isEmpty()) && (storage_account_name == null || storage_account_name.isEmpty())) {
+            throw new IllegalArgumentException("Either connection_string or storage_account_name must be configured.");
         }
         // Let's inform users here that https would be preferred
-        if (!use_https) {
+        if (!use_https && (connection_string == null || connection_string.isEmpty())) {
             log.warn("Configuration is using HTTP, consider switching to HTTPS instead.");
         }
 

--- a/src/test/java/org/jgroups/protocols/azure/AZURE_PINGConfigurationTest.java
+++ b/src/test/java/org/jgroups/protocols/azure/AZURE_PINGConfigurationTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  */
 public class AZURE_PINGConfigurationTest {
 
-    private AZURE_PING azure;
+    private final AZURE_PING azure;
 
     public AZURE_PINGConfigurationTest() {
         azure = new AZURE_PING();
@@ -47,6 +47,29 @@ public class AZURE_PINGConfigurationTest {
     @Test
     public void testValidationWithoutAccessKey() {
         azure.storage_account_name = "myaccount";
+        azure.container = "mycontainer";
+        azure.validateConfiguration();
+    }
+
+    @Test
+    public void testValidationWithConnectionString() {
+        azure.connection_string = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net";
+        azure.storage_account_name = "myaccount";
+        azure.container = "mycontainer";
+        azure.validateConfiguration();
+    }
+
+    @Test
+    public void testValidationWithConnectionStringWithoutAccountName() {
+        azure.connection_string = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net";
+        azure.container = "mycontainer";
+        azure.validateConfiguration();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidationWithEmptyConnectionStringAndEmptyAccountName() {
+        azure.connection_string = "";
+        azure.storage_account_name = "";
         azure.container = "mycontainer";
         azure.validateConfiguration();
     }

--- a/src/test/java/org/jgroups/protocols/azure/AbstractAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/AbstractAZURE_PINGDiscoveryTestCase.java
@@ -27,7 +27,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Functional tests for AZURE_PING discovery.
+ * Base class for functional tests for AZURE_PING discovery.
+ * All implementations of this class only configure properties that are consumed by the stack file (tcp-azure.xml).
  *
  * @author Radoslav Husar
  */
@@ -37,12 +38,12 @@ public abstract class AbstractAZURE_PINGDiscoveryTestCase {
     public static final int CHANNEL_COUNT = 5;
 
     // The cluster names need to randomized so that multiple test runs can be run in parallel with the same
-    // credentials (e.g. running JDK8 and JDK9 on the CI).
+    // credentials (e.g. running JDK 17 and JDK 25 in CI).
     public static final String RANDOM_CLUSTER_NAME = UUID.randomUUID().toString();
 
     // Captured at class-load time, before any test's @BeforeClass can set these properties (e.g. Azurite test).
-    private static final boolean GENUINE_CREDENTIALS_AVAILABLE =
-            System.getProperty("azure.access_key") != null && System.getProperty("azure.account_name") != null;
+    private static final boolean GENUINE_CREDENTIALS_AVAILABLE = System.getProperty("azure.connection_string") != null ||
+            (System.getProperty("azure.access_key") != null && System.getProperty("azure.account_name") != null);
 
     static boolean areGenuineCredentialsAvailable() {
         return GENUINE_CREDENTIALS_AVAILABLE;

--- a/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
@@ -16,32 +16,57 @@
 
 package org.jgroups.protocols.azure;
 
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.jgroups.util.Util;
 import org.junit.AfterClass;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
-import static org.junit.Assert.fail;
-
 /**
- * Tests against a containerized Azurite service.
+ * Tests against a containerized Azurite service using both blob_storage_uri and connection_string.
  *
  * @author Radoslav Husar
  */
+@RunWith(Parameterized.class)
 public class AzuriteAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscoveryTestCase {
 
+    public enum ConfigurationType {
+        BLOB_STORAGE_URI,
+        CONNECTION_STRING,
+    }
+
+    // These are fixed; well-known configuration properties for Azurite container
     private static final String AZURITE_ACCOUNT_NAME = "devstoreaccount1";
     private static final String AZURITE_ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
     private static final int AZURITE_BLOB_PORT = 10000;
-    private static final String[] PROPERTY_KEYS = {"azure.blob_storage_uri", "azure.account_name", "azure.access_key", "azure.container"};
+
+    // All known property keys used in the tcp-azure.xml stack file
+    private static final String[] PROPERTY_KEYS = {"azure.connection_string", "azure.blob_storage_uri", "azure.account_name", "azure.access_key", "azure.container"};
 
     private static GenericContainer<?> azurite;
     private static final Map<String, String> savedProperties = new HashMap<>();
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<ConfigurationType> data() {
+        return Arrays.asList(ConfigurationType.values());
+    }
+
+    private final ConfigurationType configurationType;
+
+    public AzuriteAZURE_PINGDiscoveryTestCase(ConfigurationType configurationType) {
+        this.configurationType = configurationType;
+    }
 
     @BeforeClass
     public static void setUp() {
@@ -61,21 +86,34 @@ public class AzuriteAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscov
         azurite.start();
 
         // Save existing properties to restore after tests
-        for (String key : PROPERTY_KEYS) {
-            savedProperties.put(key, System.getProperty(key));
-        }
+        Arrays.stream(PROPERTY_KEYS).forEach(key -> savedProperties.put(key, System.getProperty(key)));
+    }
 
-        // Configure the protocol with Azurite well-known credentials and dynamic endpoint
-        String blobStorageUri = "http://" + azurite.getHost() + ":" + azurite.getMappedPort(AZURITE_BLOB_PORT) + "/" + AZURITE_ACCOUNT_NAME;
-        System.setProperty("azure.blob_storage_uri", blobStorageUri);
-        System.setProperty("azure.account_name", AZURITE_ACCOUNT_NAME);
-        System.setProperty("azure.access_key", AZURITE_ACCOUNT_KEY);
-        System.setProperty("azure.container", "ping");
+    @Before
+    public void setUpProperties() {
+        // Start each test with unset properties
+        Arrays.stream(PROPERTY_KEYS).forEach(System::clearProperty);
+
+        String blobEndpoint = "http://" + azurite.getHost() + ":" + azurite.getMappedPort(AZURITE_BLOB_PORT) + "/" + AZURITE_ACCOUNT_NAME;
+
+        switch (configurationType) {
+            case BLOB_STORAGE_URI:
+                // Configure using individual properties
+                System.setProperty("azure.blob_storage_uri", blobEndpoint);
+                System.setProperty("azure.account_name", AZURITE_ACCOUNT_NAME);
+                System.setProperty("azure.access_key", AZURITE_ACCOUNT_KEY);
+                break;
+            case CONNECTION_STRING:
+                // Configure using connection string; clear individual credential properties
+                String connectionString = String.format("DefaultEndpointsProtocol=http;AccountName=%s;AccountKey=%s;BlobEndpoint=%s", AZURITE_ACCOUNT_NAME, AZURITE_ACCOUNT_KEY, blobEndpoint);
+                System.setProperty("azure.connection_string", connectionString);
+                break;
+        }
     }
 
     @AfterClass
     public static void cleanup() {
-        // Restore original properties so that GenuineAZURE_PINGDiscoveryTestCase picks up genuine credentials
+        // Restore original properties so that GenuineAZURE_PINGDiscoveryTestCase picks up genuine credentials passed by the user
         for (Map.Entry<String, String> entry : savedProperties.entrySet()) {
             if (entry.getValue() != null) {
                 System.setProperty(entry.getKey(), entry.getValue());

--- a/src/test/resources/org/jgroups/protocols/azure/tcp-azure.xml
+++ b/src/test/resources/org/jgroups/protocols/azure/tcp-azure.xml
@@ -29,10 +29,12 @@
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.5.xsd">
     <include file="${transport-config:tcp-default.xml}"/>
-    <azure.AZURE_PING storage_account_name="${azure.account_name}"
-                      storage_access_key="${azure.access_key}"
-                      container="${azure.container:ping}"
-                      blob_storage_uri="${azure.blob_storage_uri:}"/>
+    <azure.AZURE_PING container="${azure.container:ping}"
+                      storage_account_name="${azure.account_name:}"
+                      storage_access_key="${azure.access_key:}"
+                      blob_storage_uri="${azure.blob_storage_uri:}"
+                      connection_string="${azure.connection_string:}"
+    />
     <MERGE3 min_interval="10s"
             max_interval="30s"/>
     <FD_SOCK2/>


### PR DESCRIPTION
Add support for a connection_string property as an alternative to specifying storage_account_name and storage_access_key separately, using BlobServiceClientBuilder.connectionString().