### PR TITLE
Add environment variable support to AZURE_PING properties; fixes #253

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,16 +10,49 @@ Azure Java SDK.
 
 === Properties
 
+[align="left",cols="3,1,10",options="header"]
 |===
-|Property name |Description |Required / Default value 
+| Attribute Name +
+Environment variable
+| Default
+| Description
 
-|`storage_account_name` |The name of the storage account. |_Required (unless `connection_string` is set)._
-|`storage_access_key` |The secret account access key. If not specified, `DefaultAzureCredential` is used instead. |_Optional._
-|`connection_string` |Azure Storage connection string. When set, overrides `storage_account_name`, `storage_access_key`, `use_https`, `endpoint_suffix`, and `blob_storage_uri`. |_Optional._
-|`container` |Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL. |_Required._
-|`use_https` |Whether or not to use HTTPS to connect to Azure. |`true`
-|`endpoint_suffix` |The endpointSuffix to use. |
-|`blob_storage_uri` |The full blob service endpoint URI. When set, overrides `use_https` and `endpoint_suffix`. |
+| `container` +
+Environment variable: `JGROUPS_AZURE_CONTAINER`
+| *required*
+| Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL.
+
+| `storage_account_name` +
+Environment variable: `JGROUPS_AZURE_STORAGE_ACCOUNT_NAME`
+| *required* (unless `connection_string` is set)
+| The name of the storage account.
+
+| `storage_access_key` +
+Environment variable: `JGROUPS_AZURE_STORAGE_ACCESS_KEY`
+|
+| The secret account access key. If not specified, `DefaultAzureCredential` is used instead.
+
+| `use_https` +
+Environment variable: `JGROUPS_AZURE_USE_HTTPS`
+| `true`
+| Whether or not to use HTTPS to connect to Azure.
+
+| `endpoint_suffix` +
+Environment variable: `JGROUPS_AZURE_ENDPOINT_SUFFIX`
+| `core.windows.net`
+| The endpointSuffix to use.
+
+| `blob_storage_uri` +
+Environment variable: `JGROUPS_AZURE_BLOB_STORAGE_URI`
+|
+| The full blob service endpoint URI. When set, overrides `use_https` and `endpoint_suffix`.
+
+
+| `connection_string` +
+Environment variable: `JGROUPS_AZURE_CONNECTION_STRING`
+|
+| Azure Storage connection string. When set, overrides `storage_account_name`, `storage_access_key`, `use_https`, `endpoint_suffix`, and `blob_storage_uri`.
+
 |===
 
 === WildFly 10.1 or later / JBoss EAP 7.0 or later

--- a/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
+++ b/src/main/java/org/jgroups/protocols/azure/AZURE_PING.java
@@ -47,28 +47,38 @@ public class AZURE_PING extends FILE_PING {
 
     private static final Log log = LogFactory.getLog(AZURE_PING.class);
 
-    @Property(description = "The name of the storage account.")
+    @Property(description = "The name of the storage account.",
+            systemProperty = "JGROUPS_AZURE_STORAGE_ACCOUNT_NAME")
     protected String storage_account_name;
 
-    @Property(description = "The secret account access key. If not specified, DefaultAzureCredential is used instead.", exposeAsManagedAttribute = false)
+    @Property(description = "The secret account access key. If not specified, DefaultAzureCredential is used instead.",
+            systemProperty = "JGROUPS_AZURE_STORAGE_ACCESS_KEY",
+            exposeAsManagedAttribute = false)
     protected String storage_access_key;
 
-    @Property(description = "Azure Storage connection string. When set, overrides storage_account_name, storage_access_key, use_https, endpoint_suffix, and blob_storage_uri.", exposeAsManagedAttribute = false)
+    @Property(description = "Azure Storage connection string. When set, overrides storage_account_name, storage_access_key, use_https, endpoint_suffix, and blob_storage_uri.",
+            systemProperty = "JGROUPS_AZURE_CONNECTION_STRING",
+            exposeAsManagedAttribute = false)
     protected String connection_string;
 
-    @Property(description = "Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL.")
+    @Property(description = "Container to store ping information in. Must be a valid DNS name as it becomes part of the Azure blob storage URL.",
+            systemProperty = "JGROUPS_AZURE_CONTAINER")
     protected String container;
 
-    @Property(description = "Whether or not to use HTTPS to connect to Azure.")
+    @Property(description = "Whether or not to use HTTPS to connect to Azure.",
+            systemProperty = "JGROUPS_AZURE_USE_HTTPS")
     protected boolean use_https = true;
 
-    @Property(description = "The endpointSuffix to use.")
-    protected String endpoint_suffix;
+    @Property(description = "The endpointSuffix to use.",
+            systemProperty = "JGROUPS_AZURE_ENDPOINT_SUFFIX")
+    protected String endpoint_suffix = DEFAULT_ENDPOINT_SUFFIX;
 
-    // n.b. primarily used for testing with Azurite where the endpoint needs to be overridden; exposed here for more configuration flexibility
-    @Property(description = "The full blob service endpoint URI. When set, overrides use_https and endpoint_suffix.")
+    @Property(description = "The full blob service endpoint URI. When set, overrides use_https and endpoint_suffix.",
+            systemProperty = "JGROUPS_AZURE_BLOB_STORAGE_URI",
+            exposeAsManagedAttribute = false)
     protected String blob_storage_uri;
 
+    private static final String DEFAULT_ENDPOINT_SUFFIX = "core.windows.net";
     private static final String CLUSTER_ADDRESS_FILE_NAME_SEPARATOR = "-";
     public static final int STREAM_BUFFER_SIZE = 4096;
 
@@ -114,7 +124,7 @@ public class AZURE_PING extends FILE_PING {
                 if (blob_storage_uri != null && !blob_storage_uri.isEmpty()) {
                     builder.endpoint(blob_storage_uri);
                 } else {
-                    String suffix = (endpoint_suffix != null) ? endpoint_suffix : "core.windows.net";
+                    String suffix = (endpoint_suffix != null && !endpoint_suffix.isEmpty()) ? endpoint_suffix : DEFAULT_ENDPOINT_SUFFIX;
                     String protocol = use_https ? "https" : "http";
                     builder.endpoint(String.format("%s://%s.blob.%s", protocol, storage_account_name, suffix));
                 }


### PR DESCRIPTION
Add systemProperty to all @Property annotations enabling configuration via environment variables (JGROUPS_AZURE_* prefix). Also default endpoint_suffix to "core.windows.net" on the field declaration to make it apparent.