### PR TITLE
Simplify test configuration and document RBAC authentication; fixes #261

### DIFF
--- a/DESIGN.adoc
+++ b/DESIGN.adoc
@@ -35,6 +35,9 @@ To find out the storage account values, do the following:
 . Create a new Storage account or navigate to an existing one
 . Navigate to "Security + networking" -> "Access keys" to retrieve the account name and access key or "Connection string"
 
+When using `DefaultAzureCredential` instead of access keys, the `Storage Blob Data Contributor` RBAC role must be assigned to the identity on the storage account.
+See the README for Azure CLI commands to set this up.
+
 == Design
 
 The implementation uses Azure Storage Blob SDK 12.x and extends FILE_PING.
@@ -61,8 +64,7 @@ The shutdown hook inherited from FILE_PING is disabled by default. (since 3.0)
 == Testing
 
 The test suite includes configuration validation unit tests as well as functional discovery tests.
-The functional tests run against both a live Azure Storage endpoint (when credentials are provided) and
-an emulated https://github.com/Azure/Azurite[Azurite] blob service running in a container.
+The functional tests run against both a live Azure Storage endpoint (when credentials are provided) and an emulated https://github.com/Azure/Azurite[Azurite] blob service running in a container. (since 3.0)
 
 == Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = JGroups Azure
 :toc:
 
-image:https://github.com/jgroups-extras/jgroups-azure/workflows/CI/badge.svg[CI,link=https://github.com/jgroups-extras/jgroups-azure/actions]
+image:https://github.com/jgroups-extras/jgroups-azure/workflows/Maven/badge.svg[CI,link=https://github.com/jgroups-extras/jgroups-azure/actions]
 
 Implementation of Azure ping protocol using Azure Storage blobs for http://www.jgroups.org/[JGroups] project using official Microsoft
 Azure Java SDK.
@@ -134,24 +134,56 @@ Or use Maven wrapper for convenience:
 
 == Testing
 
-To run all tests, credentials for Azure are expected. These can be supplied either using individual properties for tests:
-
-----
-export account_name=foo
-export access_key=bar
-mvn test -Dazure.account_name="${account_name}" -Dazure.access_key="${access_key}" -Djava.net.preferIPv4Stack=true
-----
-
-or a connection string can be used:
-
-----
-mvn test -Dazure.connection_string="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
-----
-
+To run tests against genuine Azure, credentials must be provided.
 If valid credentials are not provided, tests that require them are skipped (using `org.junit.Assume`).
+
+=== Using `DefaultAzureCredential`
+
+When no access key or connection string is provided, `DefaultAzureCredential` is used.
+This requires logging in with Azure CLI and having the `Storage Blob Data Contributor` https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor[role] assigned:
+
+[source,shell]
+----
+az login
+
+az group list --output table
+az storage account list --output table
+
+az role assignment create \
+  --assignee "$(az ad signed-in-user show --query id -o tsv)" \
+  --role "Storage Blob Data Contributor" \
+  --scope "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.Storage/storageAccounts/<ACCOUNT_NAME>"
+----
+
+NOTE: Role assignment propagation can take several minutes after initial assignment.
+
+Then run the tests:
+
+[source,shell]
+----
+mvn test -DJGROUPS_AZURE_STORAGE_ACCOUNT_NAME=<ACCOUNT_NAME>
+----
+
+=== Using access key
+
+[source,shell]
+----
+mvn test -DJGROUPS_AZURE_STORAGE_ACCOUNT_NAME=<ACCOUNT_NAME> -DJGROUPS_AZURE_STORAGE_ACCESS_KEY=<ACCESS_KEY>
+----
+
+=== Using connection string
+
+[source,shell]
+----
+mvn test -DJGROUPS_AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+----
+
+=== Azurite (emulated)
 
 There are also variants of the tests that run against a mock Blob service running in a container.
 To run those tests, a valid podman/Docker environment is required.
+
+NOTE: Depending on your testing environment, you may need to append `-Djava.net.preferIPv4Stack=true` if you are having IPv6 configuration issues.
 
 == Support Matrix
 

--- a/src/test/java/org/jgroups/protocols/azure/AbstractAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/AbstractAZURE_PINGDiscoveryTestCase.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 public abstract class AbstractAZURE_PINGDiscoveryTestCase {
 
     public static final String STACK_XML_CONFIGURATION = "org/jgroups/protocols/azure/tcp-azure.xml";
+    public static final String DEFAULT_CONTAINER = "jgroups-ping-testing";
     public static final int CHANNEL_COUNT = 5;
 
     // The cluster names need to randomized so that multiple test runs can be run in parallel with the same
@@ -42,8 +43,7 @@ public abstract class AbstractAZURE_PINGDiscoveryTestCase {
     public static final String RANDOM_CLUSTER_NAME = UUID.randomUUID().toString();
 
     // Captured at class-load time, before any test's @BeforeClass can set these properties (e.g. Azurite test).
-    private static final boolean GENUINE_CREDENTIALS_AVAILABLE = System.getProperty("azure.connection_string") != null ||
-            (System.getProperty("azure.access_key") != null && System.getProperty("azure.account_name") != null);
+    private static final boolean GENUINE_CREDENTIALS_AVAILABLE = System.getProperty("JGROUPS_AZURE_CONNECTION_STRING") != null || System.getProperty("JGROUPS_AZURE_STORAGE_ACCOUNT_NAME") != null;
 
     static boolean areGenuineCredentialsAvailable() {
         return GENUINE_CREDENTIALS_AVAILABLE;

--- a/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/AzuriteAZURE_PINGDiscoveryTestCase.java
@@ -51,8 +51,8 @@ public class AzuriteAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscov
     private static final String AZURITE_ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
     private static final int AZURITE_BLOB_PORT = 10000;
 
-    // All known property keys used in the tcp-azure.xml stack file
-    private static final String[] PROPERTY_KEYS = {"azure.connection_string", "azure.blob_storage_uri", "azure.account_name", "azure.access_key", "azure.container"};
+    // All known property keys matching @Property(systemProperty = ...) in AZURE_PING
+    private static final String[] PROPERTY_KEYS = {"JGROUPS_AZURE_CONNECTION_STRING", "JGROUPS_AZURE_BLOB_STORAGE_URI", "JGROUPS_AZURE_STORAGE_ACCOUNT_NAME", "JGROUPS_AZURE_STORAGE_ACCESS_KEY", "JGROUPS_AZURE_CONTAINER"};
 
     private static GenericContainer<?> azurite;
     private static final Map<String, String> savedProperties = new HashMap<>();
@@ -96,17 +96,19 @@ public class AzuriteAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscov
 
         String blobEndpoint = "http://" + azurite.getHost() + ":" + azurite.getMappedPort(AZURITE_BLOB_PORT) + "/" + AZURITE_ACCOUNT_NAME;
 
+        System.setProperty("JGROUPS_AZURE_CONTAINER", DEFAULT_CONTAINER);
+
         switch (configurationType) {
             case BLOB_STORAGE_URI:
                 // Configure using individual properties
-                System.setProperty("azure.blob_storage_uri", blobEndpoint);
-                System.setProperty("azure.account_name", AZURITE_ACCOUNT_NAME);
-                System.setProperty("azure.access_key", AZURITE_ACCOUNT_KEY);
+                System.setProperty("JGROUPS_AZURE_BLOB_STORAGE_URI", blobEndpoint);
+                System.setProperty("JGROUPS_AZURE_STORAGE_ACCOUNT_NAME", AZURITE_ACCOUNT_NAME);
+                System.setProperty("JGROUPS_AZURE_STORAGE_ACCESS_KEY", AZURITE_ACCOUNT_KEY);
                 break;
             case CONNECTION_STRING:
                 // Configure using connection string; clear individual credential properties
                 String connectionString = String.format("DefaultEndpointsProtocol=http;AccountName=%s;AccountKey=%s;BlobEndpoint=%s", AZURITE_ACCOUNT_NAME, AZURITE_ACCOUNT_KEY, blobEndpoint);
-                System.setProperty("azure.connection_string", connectionString);
+                System.setProperty("JGROUPS_AZURE_CONNECTION_STRING", connectionString);
                 break;
         }
     }

--- a/src/test/java/org/jgroups/protocols/azure/GenuineAZURE_PINGDiscoveryTestCase.java
+++ b/src/test/java/org/jgroups/protocols/azure/GenuineAZURE_PINGDiscoveryTestCase.java
@@ -29,5 +29,9 @@ public class GenuineAZURE_PINGDiscoveryTestCase extends AbstractAZURE_PINGDiscov
     @BeforeClass
     public static void assumeCredentials() {
         Assume.assumeTrue("Credentials are not available, test will be ignored!", areGenuineCredentialsAvailable());
+
+        if (System.getProperty("JGROUPS_AZURE_CONTAINER") == null) {
+            System.setProperty("JGROUPS_AZURE_CONTAINER", DEFAULT_CONTAINER);
+        }
     }
 }

--- a/src/test/resources/org/jgroups/protocols/azure/tcp-azure.xml
+++ b/src/test/resources/org/jgroups/protocols/azure/tcp-azure.xml
@@ -29,12 +29,7 @@
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.5.xsd">
     <include file="${transport-config:tcp-default.xml}"/>
-    <azure.AZURE_PING container="${azure.container:ping}"
-                      storage_account_name="${azure.account_name:}"
-                      storage_access_key="${azure.access_key:}"
-                      blob_storage_uri="${azure.blob_storage_uri:}"
-                      connection_string="${azure.connection_string:}"
-    />
+    <azure.AZURE_PING/>
     <MERGE3 min_interval="10s"
             max_interval="30s"/>
     <FD_SOCK2/>


### PR DESCRIPTION
Remove redundant property mappings from tcp-azure.xml test stack and rely on @Property(systemProperty = ...) for resolving JGROUPS_AZURE_* properties. Update test credential check to support DefaultAzureCredential (account name only, without access key). Document all three authentication methods for testing including Azure RBAC setup with az CLI commands.